### PR TITLE
Improvements to Line Markers and Debug Fails

### DIFF
--- a/src/main/kotlin/net/thoughtmachine/please/plugin/pleasecommandline/PleaseCommandLine.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/pleasecommandline/PleaseCommandLine.kt
@@ -8,7 +8,7 @@ typealias PleaseCommand = List<String>
 
 class Please(
     private val project: Project,
-    private val verbosity: String = "info",
+    private val verbosity: String = "warning",
     private val plainOutput : Boolean = true,
     private val config : String = "dbg",
     private val pleaseArgs: List<String> = emptyList()
@@ -45,6 +45,12 @@ class Please(
         }
         args.add("--")
         args.addAll(execCmd)
+        return args
+    }
+
+    fun query(subcommand: String, arguments: Array<String>) : PleaseCommand {
+        val args = args().toMutableList()
+        args.addAll(listOf("query", subcommand, *arguments))
         return args
     }
 

--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/GoStateProvider.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/GoStateProvider.kt
@@ -139,8 +139,8 @@ class PleaseGoDebugState(
             }
 
             override fun onThrowable(error: Throwable) {
-                Notifications.Bus.notify(Notification("Please", "Failed build ${config.target()}", error.message!!, NotificationType.ERROR))
-                promise.setResult(null)
+                Notifications.Bus.notify(Notification("Please", "Failed build ${config.target()}", "", NotificationType.ERROR))
+                promise.setResult(execute())
             }
 
             override fun run(indicator: ProgressIndicator) {

--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/PleaseGoLineMarkerProvider.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/PleaseGoLineMarkerProvider.kt
@@ -57,7 +57,6 @@ object PleaseGoLineMarkerProvider : RunLineMarkerContributor() {
                 if (!GoTestifySupport.isRunnableTestifyMethod(parent)) {
                     return null
                 }
-
                 val receiverType = GoPsiImplUtil.unwrapPointerIfNeeded(parent.receiverType) ?: return null
 
                 val subTestName = findSuiteTestName(element.containingFile as GoFile, (receiverType.resolve(parent) as GoTypeSpec).name!!)

--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/PleaseGoLineMarkerProvider.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/PleaseGoLineMarkerProvider.kt
@@ -21,6 +21,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
+import net.thoughtmachine.please.plugin.pleasecommandline.Please
 import net.thoughtmachine.please.plugin.runconfiguration.PleaseAction
 import net.thoughtmachine.please.plugin.runconfiguration.PleaseLineMarkerProvider
 
@@ -53,9 +54,12 @@ object PleaseGoLineMarkerProvider : RunLineMarkerContributor() {
                 test = parent.name ?: ""
             }
             is GoMethodDeclaration -> {
+                System.out.println("found go method")
                 if (!GoTestifySupport.isRunnableTestifyMethod(parent)) {
                     return null
                 }
+                System.out.println("found go method asd")
+
                 val receiverType = GoPsiImplUtil.unwrapPointerIfNeeded(parent.receiverType) ?: return null
 
                 val subTestName = findSuiteTestName(element.containingFile as GoFile, (receiverType.resolve(parent) as GoTypeSpec).name!!)
@@ -118,7 +122,7 @@ object PleaseGoLineMarkerProvider : RunLineMarkerContributor() {
         val pleaseRoot = findPleaseRoot(file.virtualFile) ?: return null
         val path = pleaseRoot.toNioPath().relativize(file.virtualFile.toNioPath())
 
-        val cmd = GeneralCommandLine("plz query whatinputs $path".split(" "))
+        val cmd = GeneralCommandLine(Please(file.project).query("whatinputs", arrayOf(path.toString())))
         cmd.workDirectory = file.project.guessProjectDir()!!.toNioPath().toFile()
         cmd.withRedirectErrorStream(true)
 

--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/PleaseGoLineMarkerProvider.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/PleaseGoLineMarkerProvider.kt
@@ -54,11 +54,9 @@ object PleaseGoLineMarkerProvider : RunLineMarkerContributor() {
                 test = parent.name ?: ""
             }
             is GoMethodDeclaration -> {
-                System.out.println("found go method")
                 if (!GoTestifySupport.isRunnableTestifyMethod(parent)) {
                     return null
                 }
-                System.out.println("found go method asd")
 
                 val receiverType = GoPsiImplUtil.unwrapPointerIfNeeded(parent.receiverType) ?: return null
 


### PR DESCRIPTION
On a debug failure, open in the terminal rather than in a notification balloon. Also make line markers only show the relevant commands for the rule.

Closes #43 
Closes #8 
