### PR TITLE
Make the non-plain output work in the ProcessHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,3 +32,7 @@ compileTestKotlin {
 }
 
 sourceSets["main"].java.srcDirs("src/main/gen")
+
+runIde {
+    jvmArgs '-Xmx4G'
+}

--- a/src/main/kotlin/net/thoughtmachine/please/plugin/pleasecommandline/PleaseCommandLine.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/pleasecommandline/PleaseCommandLine.kt
@@ -8,8 +8,7 @@ typealias PleaseCommand = List<String>
 
 class Please(
     private val project: Project,
-    private val verbosity: String = "warning",
-    private val plainOutput : Boolean = true,
+    private val plainOutput : Boolean = false,
     private val config : String = "dbg",
     private val pleaseArgs: List<String> = emptyList()
 ) {
@@ -56,9 +55,9 @@ class Please(
 
     fun args() : List<String> {
         val plz = PleaseProjectConfigurable.getPleasePath(project)
-        val args = mutableListOf(plz, "-v", verbosity, "-c", config)
+        val args = mutableListOf(plz, "-c", config)
         if(plainOutput) {
-            args.add("-p")
+            args.addAll(listOf("-p", "-v", "warning"))
         }
         args.addAll(pleaseArgs)
         return args

--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/ProcessHandler.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/ProcessHandler.kt
@@ -1,0 +1,24 @@
+package net.thoughtmachine.please.plugin.runconfiguration
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.KillableProcessHandler
+import com.intellij.util.io.BaseDataReader
+import com.intellij.util.io.BaseOutputReader
+
+class PleaseProcessHandler(cmd: GeneralCommandLine) : KillableProcessHandler(cmd) {
+    override fun readerOptions(): BaseOutputReader.Options {
+        return object : BaseOutputReader.Options() {
+            override fun policy(): BaseDataReader.SleepingPolicy {
+                return BaseDataReader.SleepingPolicy.BLOCKING
+            }
+
+            override fun splitToLines(): Boolean {
+                return false
+            }
+
+            override fun withSeparators(): Boolean {
+                return true
+            }
+        }
+    }
+}

--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/RunStates.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/RunStates.kt
@@ -6,15 +6,19 @@ import com.intellij.execution.Executor
 import com.intellij.execution.configurations.PtyCommandLine
 import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.executors.DefaultRunExecutor
-import com.intellij.execution.filters.TextConsoleBuilderFactory
+import com.intellij.execution.impl.ConsoleViewImpl
+import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.execution.process.ProcessHandler
-import com.intellij.execution.process.ProcessHandlerFactoryImpl
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.execution.ui.ConsoleView
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.project.Project
+import com.intellij.terminal.TerminalExecutionConsole
+import com.intellij.util.io.BaseDataReader.SleepingPolicy
+import com.intellij.util.io.BaseOutputReader
 import net.thoughtmachine.please.plugin.pleasecommandline.PleaseCommand
 import javax.swing.Icon
+
 
 object PleaseBuildExecutor : DefaultRunExecutor() {
     override fun getIcon(): Icon {
@@ -27,7 +31,8 @@ object PleaseBuildExecutor : DefaultRunExecutor() {
 }
 
 fun (Project).createConsole(processHandler: ProcessHandler): ConsoleView {
-    val console = TextConsoleBuilderFactory.getInstance().createBuilder(this).console
+    val console = TerminalExecutionConsole(this, processHandler)
+
     console.attachToProcess(processHandler)
     return console
 }
@@ -39,7 +44,8 @@ class PleaseProfileState(
     private fun startProcess(): ProcessHandler {
         val cmd = PtyCommandLine(pleaseCommand)
         cmd.setWorkDirectory(project.basePath!!)
-        return ProcessHandlerFactoryImpl.getInstance().createColoredProcessHandler(cmd)
+
+        return PleaseProcessHandler(cmd)
     }
 
     override fun execute(executor: Executor?, runner: ProgramRunner<*>): ExecutionResult {

--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/GoStateProvider.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/GoStateProvider.kt
@@ -6,6 +6,7 @@ import com.intellij.execution.DefaultExecutionResult
 import com.intellij.execution.ExecutionResult
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.PtyCommandLine
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessHandlerFactory
 import com.intellij.execution.process.ProcessHandlerFactoryImpl
@@ -62,7 +63,7 @@ class PleaseGoDebugState(
 
     private fun getPleaseVersion() : SemVer? {
         val cmd = GeneralCommandLine(Please(config.project).version())
-        val process = ProcessHandlerFactory.getInstance().createProcessHandler(cmd)
+        val process = PleaseProcessHandler(cmd)
         if (process.process.waitFor() == 0) {
             val output = String(process.process.inputStream.readAllBytes())
                 .removePrefix("Please version ")
@@ -86,7 +87,7 @@ class PleaseGoDebugState(
         ))
         //TODO(jpoole): this should use the files project root
         cmd.setWorkDirectory(config.project.basePath!!)
-        return ProcessHandlerFactoryImpl.getInstance().createColoredProcessHandler(cmd)
+        return PleaseProcessHandler(cmd)
     }
 
     private fun startForPleaseTest(config: PleaseTestConfiguration): ProcessHandler {
@@ -110,7 +111,7 @@ class PleaseGoDebugState(
 
         //TODO(jpoole): this should use the files project root
         cmd.setWorkDirectory(config.project.basePath!!)
-        return ProcessHandlerFactoryImpl.getInstance().createColoredProcessHandler(cmd)
+        return PleaseProcessHandler(cmd)
     }
 
     private fun startProcess() : ProcessHandler {


### PR DESCRIPTION
Adds a new process handler that doesn't screw around with trying to parse out new lines. These were breaking the control characters to clear lines in the non-plain output from Please. 