### PR TITLE
Ignore failing to complete labels

### DIFF
--- a/src/main/kotlin/net/thoughtmachine/please/plugin/labels/BuildLabelCompletionContributor.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/labels/BuildLabelCompletionContributor.kt
@@ -61,8 +61,6 @@ class BuildLabelCompletionProvider : CompletionProvider<CompletionParameters>() 
                 .map { it.removePrefix("//").removePrefix(":") }
                 .collect(Collectors.toList()).take(50)
         } else {
-            val error = String(process.process.inputStream.readAllBytes())
-            Notifications.Bus.notify(Notification("Please", "Failed to complete label", error, NotificationType.ERROR))
             emptyList()
         }
     }


### PR DESCRIPTION
This can happen for a number of reasons e.g. partially edited build files. We don't really want to spit out this error each time. 

Going forward, we should probably complete based on the file system and Psi targets in that package. Right now this is a little hacky. 