### PR TITLE
Don't allow null file

### DIFF
--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/PleaseConfigurationBase.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/PleaseConfigurationBase.kt
@@ -110,7 +110,10 @@ interface PleaseRunConfigurationBase : DebuggableRunConfiguration {
 
 abstract class PleaseRunConfigurationProducerBase<T:PleaseRunConfigurationBase>: LazyRunConfigurationProducer<T>() {
     fun file(element: PsiElement) : PleaseFile? {
-        val file = element.containingFile ?: return null
+        if(element.containingFile == null) {
+            return null
+        }
+        val file = element.containingFile
         // Skip build defs as they don't define build rules
         if(file.fileType != PleaseBuildFileType) {
             return null


### PR DESCRIPTION
Could be wrong about this but this crash:
```java.lang.NullPointerException: Cannot invoke "com.intellij.psi.PsiFile.getFileType()" because "file" is null
	at net.thoughtmachine.please.plugin.runconfiguration.PleaseRunConfigurationProducerBase.file(PleaseConfigurationBase.kt:115)
	at net.thoughtmachine.please.plugin.runconfiguration.PleaseRunConfigurationProducerBase.setupConfigurationFromContext(PleaseConfigurationBase.kt:135)
	at net.thoughtmachine.please.plugin.runconfiguration.PleaseRunConfigurationProducerBase.setupConfigurationFromContext(PleaseConfigurationBase.kt:111)
	at com.intellij.execution.actions.RunConfigurationProducer.createConfigurationFromContext(RunConfigurationProducer.java:100)
	at com.intellij.execution.actions.RunConfigurationProducer.findOrCreateConfigurationFromContext(RunConfigurationProducer.java:197)
	at com.intellij.execution.actions.PreferredProducerFind.doGetConfigurationsFromContext(PreferredProducerFind.java:118)
	at com.intellij.execution.actions.PreferredProducerFind.getConfigurationsFromContext(PreferredProducerFind.java:100)
	at com.intellij.execution.actions.ConfigurationContext.getConfigurationsFromContext(ConfigurationContext.java:413)
	at com.intellij.execution.actions.ConfigurationContext.findPreferredConfiguration(ConfigurationContext.java:292)
	at com.intellij.execution.actions.ConfigurationContext.findExisting(ConfigurationContext.java:285)
	at com.intellij.execution.actions.BaseRunConfigurationAction.findExisting(BaseRunConfigurationAction.java:65)
	at com.intellij.execution.actions.BaseRunConfigurationAction.fullUpdate(BaseRunConfigurationAction.java:220)
	at com.intellij.execution.actions.BaseRunConfigurationAction.update(BaseRunConfigurationAction.java:185)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.lambda$performDumbAwareUpdate$0(ActionUtil.java:150)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.performDumbAwareUpdate(ActionUtil.java:173)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doUpdate(ActionUpdater.java:660)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$updateActionReal$4(ActionUpdater.java:128)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.callAction(ActionUpdater.java:173)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.callAction(ActionUpdater.java:153)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.updateActionReal(ActionUpdater.java:129)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$new$0(ActionUpdater.java:116)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.update(ActionUpdater.java:649)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandGroupChild(ActionUpdater.java:498)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroup$20(ActionUpdater.java:477)
	at com.intellij.util.containers.ContainerUtil.concat(ContainerUtil.java:1398)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doExpandActionGroup(ActionUpdater.java:477)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandGroupChild(ActionUpdater.java:550)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroup$20(ActionUpdater.java:477)
	at com.intellij.util.containers.ContainerUtil.concat(ContainerUtil.java:1398)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doExpandActionGroup(ActionUpdater.java:477)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandGroupChild(ActionUpdater.java:550)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroup$20(ActionUpdater.java:477)
	at com.intellij.util.containers.ContainerUtil.concat(ContainerUtil.java:1398)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doExpandActionGroup(ActionUpdater.java:477)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandGroupChild(ActionUpdater.java:550)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroup$20(ActionUpdater.java:477)
	at com.intellij.util.containers.ContainerUtil.concat(ContainerUtil.java:1398)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doExpandActionGroup(ActionUpdater.java:477)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandGroupChild(ActionUpdater.java:550)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroup$20(ActionUpdater.java:477)
	at com.intellij.util.containers.ContainerUtil.concat(ContainerUtil.java:1398)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doExpandActionGroup(ActionUpdater.java:477)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandActionGroup(ActionUpdater.java:272)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroupAsync$12(ActionUpdater.java:340)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroupAsync$13(ActionUpdater.java:359)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1154)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$tryRunReadActionAndCancelBeforeWrite$17(ActionUpdater.java:391)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:158)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.tryRunReadActionAndCancelBeforeWrite(ActionUpdater.java:387)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroupAsync$14(ActionUpdater.java:359)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:188)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:608)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:683)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:639)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:607)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:175)
	at com.intellij.openapi.progress.util.BackgroundTaskUtil.runUnderDisposeAwareIndicator(BackgroundTaskUtil.java:365)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroupAsync$15(ActionUpdater.java:358)
	at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:241)
	at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:31)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.execute(BoundedTaskExecutor.java:214)
	at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:212)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:203)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
	at java.base/java.lang.Thread.run(Thread.java:833)```

appears to be happening because `file.fileType` calls `PsiFile.getFileType()` which doesn't like a null file. Think that binary operator is assigning null to `file` rather than returning from the function, which is what we want. @Tatskaari does that sound right?

Was trying to write a test for this but cannot for the life of me figure out java/kotlin/gradle. Wish it was built with please!