### PR TITLE
Enable go debugger for any target

### DIFF
--- a/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/GoDebugger.kt
+++ b/src/main/kotlin/net/thoughtmachine/please/plugin/runconfiguration/go/GoDebugger.kt
@@ -13,7 +13,7 @@ import java.net.InetSocketAddress
 
 object GoDebugger : PleaseDebugger {
     override fun canRun(target: BuildTarget): Boolean {
-        return target.kind == "go_test" || target.kind == "go_binary"
+        return true
     }
 
     override fun createDebugProcess(


### PR DESCRIPTION
We always have the issue where slightly different build defs that could perfectly be debugged are not enabled because they are not native please build defs.

Instead, try to debug any target, worst case scenario it fails, but at least we've tried.