### PR TITLE
Fix issue affecting debugging in IntelliJ due to missing org.apache.ant dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'net.thoughtmachine.please'
-version 'v2.1.4'
+version 'v2.1.5'
 
 repositories {
     mavenCentral()
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation "org.apache.ant:ant:1.10.15"
     compile 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -75,6 +75,8 @@
     </extensionPoints>
 
     <change-notes><![CDATA[
+        <h2>v2.1.5</h2>
+        <p>Fix issue with debugging in IntelliJ caused by NoClassDefFoundError due to missing org.apache.ant dependency
         <h2>v2.1.4</h2>
         <p>Reduce the amount of times this calls out to please
         <h2>v2.1.3</h2>


### PR DESCRIPTION
After adding missing dependency, IntelliJ plugin works as expected and debugger can be used normally.

@Tatskaari @Vaxuite  for review.